### PR TITLE
Fix dispatch on `nargin` [#1] and introduce dispatch on `nargout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Write a function like the following example as a template. Use `dispatch(varargin, methodTable)` function to invoke methods.
 ```matlab
-function out = foo(varargin)
+function varargout = foo(varargin)
 
     methodTable = {@foo1, ["any"];  % dispatch based on number of inputs
     @foo2, ["logical","logical"];   % dispatch based on type
@@ -17,7 +17,7 @@ function out = foo(varargin)
     @foo4, ["Person"];              % dispatch on class
     @foo5, ["any", "logical"]};             
 
-    out = dispatch(varargin, methodTable);
+    [varargout{1:nargout}] = dispatch(varargin, methodTable);
 
 end
 ```
@@ -37,13 +37,14 @@ function out = foo3(a, b)
     out = a * b;
 end
 
-function out = foo4(p)
-    out = p.name;
-    out = b;
+function [out1,out2] = foo4(p)
+    out1 = p.name;
+    out2 = p.age;
 end
 
-function out = foo5(a,b)
-    out = b;
+function [out1,out2] = foo5(a,b)
+    out1 = a;
+    out2 = b;
 end
 ```
 
@@ -65,14 +66,22 @@ ans =
 % dispatch based on type
 >> foo(2, true)
 ans =
-  logical
-   1
+  2
 ```
 ```matlab
-% dispatch on class
+% dispatch on number of output args
 >> p = Person("Amin",25);
->> foo(p)
-"Amin"
+>> foo(p) % dispatches on foo1
+ans = 
+  Person with properties:
+    name: "Amin"
+     age: 25
+
+>> [a,b] = foo(p) % dispatches on foo4
+a = 
+    "Amin"
+b =
+    25
 ```
 ```matlab
 % dispatch on any type
@@ -82,12 +91,14 @@ ans =
    1
 ```
 ```matlab
+% error handling
 >> foo({2},p)
 error: no method found
 ```
 
 # Note
-- You can't have multiple outputs for your function. Instead return the outputs as an array or cell of outputs.
+- ~~You can't have multiple outputs for your function. Instead return the outputs as an array or cell of outputs.~~ FIXED by @bellomia, with a soft change in API: the top-level wrapper (`foo` in the example) has to feature the [`varargout`](https://www.mathworks.com/help/matlab/ref/varargout.html) syntax.
+
 - You can't dispatch on the name of the structs. Instead define simple class with just properties (See Person).
 
 # License

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Write a function like the following example as a template. Use `dispatch(varargi
 ```matlab
 function out = foo(varargin)
 
-    methodTable = {@foo1, 1;        % dispatch based on number of inputs
+    methodTable = {@foo1, ["any"];  % dispatch based on number of inputs
     @foo2, ["logical","logical"];   % dispatch based on type
     @foo3, ["numeric", "logical"];
     @foo3, ["logical", "numeric"];  % repeated method for different type
@@ -37,12 +37,13 @@ function out = foo3(a, b)
     out = a * b;
 end
 
-function out = foo4(a,b)
+function out = foo4(p)
+    out = p.name;
     out = b;
 end
 
-function out = foo5(p)
-    out = p.name;
+function out = foo5(a,b)
+    out = b;
 end
 ```
 

--- a/dispatch.m
+++ b/dispatch.m
@@ -1,10 +1,12 @@
 % Dispatch.m
 % Runtime multiple dispatch for Matlab.
-% Apache V2 License - Copyright (c) 2020 Amin Yahyaabadi - aminyahyaabadi74@gmail.com
+% Apache V2 License
+% Copyright (c) 2020 Amin Yahyaabadi, aminyahyaabadi74@gmail.com
+% Copyright (c) 2022 Gabriele Bellomia, gbellomia@live.it [multiple output] 
 % https://github.com/aminya/Dispatch.m
 %
 % # Example
-% function out = foo(varargin)
+% function varargout = foo(varargin)
 %
 %     methodTable = {@foo1, ["any"];  % dispatch based on number of inputs
 %     @foo2, ["logical","logical"];   % dispatch based on type
@@ -13,25 +15,29 @@
 %     @foo4, ["Person"];              % dispatch on class
 %     @foo5, ["any", "logical"]};
 %
-%     out = dispatch(varargin, methodTable);
+%     [varargout{1:nargout}] = dispatch(varargin, methodTable);
 %
 % end
-function out = dispatch(var, methodTable)
+function varargout = dispatch(var, methodTable)
 
-methodNum = size(methodTable,1);
+    methodNum = size(methodTable,1);
     for i=1:methodNum
         if nargcheck(var,methodTable{i,2})
             % only check types if nargin matches
             if ismethod(var, methodTable{i,2})
-                % call the unique matching method
-                out = methodTable{i,1}(var{:});
+                % call the candidate matching method
+                try % the only way I know to check for nargout match
+                    [varargout{1:nargout}] = methodTable{i,1}(var{:});
+                catch
+                    continue % there might be another method matching
+                end
+                return
             end
         end
     end
-
-    if ~exist('out','var')
-       error("no method found")
-    end
+    
+    error("no method found")
+   
 end
 
 function out = nargcheck(var, typearray)

--- a/dispatch.m
+++ b/dispatch.m
@@ -2,13 +2,11 @@
 % Runtime multiple dispatch for Matlab.
 % Apache V2 License - Copyright (c) 2020 Amin Yahyaabadi - aminyahyaabadi74@gmail.com
 % https://github.com/aminya/Dispatch.m
-
-function out = dispatch(var, methodTable)
-% performs runtime multiple dispatch for Matlab.
+%
 % # Example
 % function out = foo(varargin)
 %
-%     methodTable = {@foo1, 1;        % dispatch based on number of inputs
+%     methodTable = {@foo1, ["any"];  % dispatch based on number of inputs
 %     @foo2, ["logical","logical"];   % dispatch based on type
 %     @foo3, ["numeric", "logical"];
 %     @foo3, ["logical", "numeric"];  % repeated method for different type
@@ -18,11 +16,16 @@ function out = dispatch(var, methodTable)
 %     out = dispatch(varargin, methodTable);
 %
 % end
+function out = dispatch(var, methodTable)
 
 methodNum = size(methodTable,1);
     for i=1:methodNum
-        if ismethod(var, methodTable{i,2})
-            out = methodTable{i,1}(var{:});
+        if nargcheck(var,methodTable{i,2})
+            % only check types if nargin matches
+            if ismethod(var, methodTable{i,2})
+                % call the unique matching method
+                out = methodTable{i,1}(var{:});
+            end
         end
     end
 
@@ -31,23 +34,26 @@ methodNum = size(methodTable,1);
     end
 end
 
+function out = nargcheck(var, typearray)
+% find if the method is correct based on number of passed arguments.
+% calls isnargin (TODO: probably better to inline)
 
-function out = ismethod(var, numOrType)
-% find if the method is correct based on number or type of arguments.
-% calls isnargin and isa_ accordingly
+    narg = length(typearray);
+    out = isnargin(var,narg);
 
-    if isa(numOrType, 'numeric')
-        out = isnargin(var, numOrType);
-    else
-        out = isa_(var, numOrType);
-    end
+end
+
+function out = ismethod(var, types)
+% find if the method is correct based on type of arguments.
+% calls isa_ (TODO: probably better to inline)
+
+    out = isa_(var, types);
 
 end
 
 
 function out = isnargin(var, num)
 % is number of var equal to num
-
    out = length(var) == num;
 end
 

--- a/foo.m
+++ b/foo.m
@@ -1,6 +1,6 @@
-function out = foo(varargin)
+function varargout = foo(varargin)
 
-    out = dispatch(varargin,...
+    [varargout{1:nargout}] = dispatch(varargin,...
         {@foo1,["any"];                 % dispatch based on number of inputs
         @foo2, ["logical","logical"];   % dispatch based on type
         @foo3, ["numeric", "logical"];
@@ -22,10 +22,12 @@ function out = foo3(a, b)
     out = a * b;
 end
 
-function out = foo4(p)
-    out = p.name;
+function [out1, out2] = foo4(p)
+    out1 = p.name;
+    out2 = p.age;
 end
 
-function out = foo5(a,b)
-    out = b;
+function [out1, out2] = foo5(a,b)
+    out1 = b;
+    out2 = a;
 end

--- a/foo.m
+++ b/foo.m
@@ -1,12 +1,12 @@
 function out = foo(varargin)
 
     out = dispatch(varargin,...
-        {@foo1, 1; % dispatch based on number of inputs
+        {@foo1,["any"];                 % dispatch based on number of inputs
         @foo2, ["logical","logical"];   % dispatch based on type
         @foo3, ["numeric", "logical"];
-        @foo3, ["logical", "numeric"]; % repeated method for different type
-        @foo4, ["any", "logical"];
-        @foo5, ["Person"]}); % dispatch on class
+        @foo3, ["logical", "numeric"];  % repeated method for different type
+        @foo4, ["Person"];              % dispatch on class
+        @foo5, ["any", "logical"]}); 
 
 end
 


### PR DESCRIPTION
Dispatch on number of input args (`nargin`) was broken for any non-numeric type (see issue #1), now is fixed by a slightly breaking change in API: no more number of arguments in the method table, but instead use `["any","any",..."any"]` to define a dispatch on arbitrary number of inputs, without any constraint on type.

Similarly I introduce here the possibility to dispatch on number of _output_ arguments (`nargout`). This removes an importan limitation of the current base implementation, at the price of some overhead (methods that are expose identical interface other than for the `nargout` would be all called in a try/catch environment). For now the actual performance cost in unknown as there is no test-suite to profile (and I foresee a few low hanging fruits for optimization already). I may contribute building that, if welcomed.